### PR TITLE
Task promotion and deletion logic improvements

### DIFF
--- a/frontend/src/components/TodoItem.tsx
+++ b/frontend/src/components/TodoItem.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 
 import { Task, TaskStatus } from '@src/models/Task';
-import { deleteTask, updateTask } from '@src/utils/todo/todo';
+import { deleteTask, getTask, updateTask } from '@src/utils/todo/todo';
 
 import TodoForm from './TodoForm';
 
@@ -116,10 +116,13 @@ export default function TodoItem({
 
   const promoteTask = async () => {
     try {
-      await updateTask(task.id, { parentId: null });
+      if (!task.parentId) return;
+      const parentTask = await getTask(task.parentId);
+      const newParentId = parentTask?.parentId ?? null;
+      await updateTask(task.id, { parentId: newParentId });
       onTasksChange();
     } catch (error) {
-      console.error('Error promoting task:', error);
+      console.error(`Error promoting task : ${error}`);
     }
   };
 
@@ -270,7 +273,7 @@ export default function TodoItem({
               className="p-1 text-slate-500 dark:text-slate-400 hover:text-sky-600 dark:hover:text-sky-400 focus:outline-none"
               title="Edit task"
               tabIndex={0}
-              onKeyDown={(e) => {
+              onKeyDown={e => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
                   startEditing();
@@ -297,7 +300,7 @@ export default function TodoItem({
               className="p-1 text-slate-500 dark:text-slate-400 hover:text-sky-600 dark:hover:text-sky-400 focus:outline-none"
               title="Add subtask"
               tabIndex={0}
-              onKeyDown={(e) => {
+              onKeyDown={e => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
                   toggleAddForm();
@@ -318,7 +321,7 @@ export default function TodoItem({
               <button
                 onClick={promoteTask}
                 className="p-1 text-slate-500 dark:text-slate-400 hover:text-sky-600 dark:hover:text-sky-400 focus:outline-none"
-                title="Move to root level"
+                title="Promote level"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -367,7 +370,7 @@ export default function TodoItem({
               className="p-1 text-slate-500 dark:text-slate-400 hover:text-red-500 dark:hover:text-red-400 focus:outline-none"
               title="Delete"
               tabIndex={0}
-              onKeyDown={(e) => {
+              onKeyDown={e => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
                   handleDelete();

--- a/frontend/src/utils/todo/todo.ts
+++ b/frontend/src/utils/todo/todo.ts
@@ -85,7 +85,7 @@ export const deleteTask = async (taskId: string): Promise<void> => {
 
   const childTasks = await getTasksByParentFromDb(taskId);
   for (const childTask of childTasks) {
-    await updateTask(childTask.id, { parentId: null });
+    await updateTask(childTask.id, { parentId: existingTask.parentId ?? null });
   }
 
   await deleteTaskFromDb(taskId);

--- a/frontend/tests/utils/todo/todo.test.ts
+++ b/frontend/tests/utils/todo/todo.test.ts
@@ -71,4 +71,14 @@ describe('todo utils', () => {
   test('deleteTask should throw if task does not exist', async () => {
     await expect(deleteTask('non-existent-id')).rejects.toThrow('Task with id non-existent-id not found');
   });
+  test('deleteTask should promote child tasks one level up', async () => {
+    const root = await createTask('Root');
+    const parent = await createTask('Parent', undefined, root.id);
+    const child = await createTask('Child', undefined, parent.id);
+
+    await deleteTask(parent.id);
+
+    const updatedChild = await getTask(child.id);
+    expect(updatedChild?.parentId).toBe(root.id);
+  });
 });


### PR DESCRIPTION
This pull request improves the logic for promoting tasks in the todo app, ensuring that when a parent task is deleted or promoted, its child tasks are correctly moved up one level in the hierarchy. It also refines keyboard accessibility and updates button labeling for clarity.

### Task promotion and deletion logic improvements

* Updated the `promoteTask` function in `TodoItem.tsx` to move a task up one level by setting its parent to its parent's parent, rather than just removing the parent reference. This ensures correct hierarchical promotion.
* Modified the `deleteTask` function in `todo.ts` so that when a parent task is deleted, its child tasks are re-parented to the deleted task's parent, maintaining the hierarchy.
* Added a new test to verify that deleting a parent task correctly promotes its child tasks one level up.

Closes #44 