### PR TITLE
[FIX] Improve the Task-list when the application reopens

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,123 @@
+import { useEffect } from 'react';
+
+import logo from '@src/assets/t8d512.jpg';
+
+type SideBarProps = {
+  selectedView: string;
+  onSelectView: (view: string) => void;
+  setSidebarOpen?: (open: boolean) => void; // Add this prop
+};
+
+export const SideBar: React.FC<SideBarProps> = ({ selectedView, onSelectView, setSidebarOpen }) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.altKey && e.key === 's') {
+        e.preventDefault();
+        setSidebarOpen && setSidebarOpen((prev: boolean) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [setSidebarOpen]);
+
+  return (
+    <div className="h-full flex flex-col bg-white dark:bg-slate-800 border-r border-slate-200 dark:border-slate-700">
+      <div className="flex flex-col justify-center items-center bg-gradient-to-r from-sky-600 to-sky-500 dark:from-sky-700 dark:to-sky-600 text-white py-6 shadow-md">
+        <img src={logo} alt="T8D logo" className="h-16 w-16 mb-2 rounded-lg shadow-md object-cover" />
+        <h1 className="text-xl font-bold">T8D</h1>
+        <p className="text-sm text-sky-100 dark:text-sky-200">Task Manager</p>
+      </div>
+
+      {typeof window !== 'undefined' && window.innerWidth < 1024 && (
+        <button
+          className="block lg:hidden ml-auto mb-2 p-2 text-slate-500 hover:text-slate-800 dark:hover:text-slate-100"
+          onClick={() => setSidebarOpen && setSidebarOpen(false)}
+          aria-label="Close sidebar"
+        >
+          <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      )}
+
+      <div className="p-4 flex-1">
+        <nav className="space-y-1">
+          <button
+            onClick={() => {
+              onSelectView('tasks');
+            }}
+            className={`flex items-center w-full px-3 py-2 text-sm rounded-md font-medium transition-colors duration-150 ${
+              selectedView === 'tasks'
+                ? 'bg-sky-100 dark:bg-sky-700 text-sky-700 dark:text-sky-100'
+                : 'text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-900 dark:hover:text-slate-100'
+            }`}
+            tabIndex={0}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onSelectView('tasks');
+              }
+            }}
+          >
+            <svg
+              className="mr-3 h-4 w-4"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+              />
+            </svg>
+            My Tasks
+          </button>
+          <button
+            onClick={() => {
+              onSelectView('settings');
+            }}
+            className={`flex items-center w-full px-3 py-2 text-sm rounded-md font-medium transition-colors duration-150 ${
+              selectedView === 'settings'
+                ? 'bg-sky-100 dark:bg-sky-700 text-sky-700 dark:text-sky-100'
+                : 'text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-900 dark:hover:text-slate-100'
+            }`}
+            tabIndex={0}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onSelectView('settings');
+              }
+            }}
+          >
+            <svg
+              className="mr-3 h-4 w-4"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+              />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            Settings
+          </button>
+        </nav>
+      </div>
+
+      <div className="flex justify-center p-3 text-xs text-slate-500 dark:text-slate-400 border-t border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50">
+        {' '}
+        <p>T8D v0.2.5</p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/TodoItem.tsx
+++ b/frontend/src/components/TodoItem.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Task, TaskStatus } from '@src/models/Task';
 import { deleteTask, getTask, updateTask } from '@src/utils/todo/todo';
@@ -14,6 +14,8 @@ interface TodoItemProps {
   onDragOver?: ((taskId: string) => void) | undefined;
   dragTarget?: string | null;
   tabIndex?: number;
+  expandedState?: Record<string, boolean>;
+  setExpandedState?: (state: Record<string, boolean>) => void;
 }
 
 export default function TodoItem({
@@ -24,8 +26,32 @@ export default function TodoItem({
   onTasksChange,
   onDragOver,
   dragTarget,
+  tabIndex,
+  expandedState,
+  setExpandedState,
 }: TodoItemProps) {
-  const [isExpanded, setIsExpanded] = useState(true);
+  // Use expandedState from parent if provided, else fallback to local state
+  const isExpandedDefault = expandedState ? !!expandedState[task.id] : true;
+  const [isExpanded, setIsExpanded] = useState(isExpandedDefault);
+
+  useEffect(() => {
+    // Sync with parent expandedState if provided
+    if (expandedState && typeof expandedState[task.id] === 'boolean') {
+      setIsExpanded(expandedState[task.id]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expandedState?.[task.id]]);
+
+  const setExpanded = (expanded: boolean) => {
+    setIsExpanded(expanded);
+    if (setExpandedState) {
+      setExpandedState({
+        ...(expandedState || {}),
+        [task.id]: expanded,
+      });
+    }
+  };
+
   const [isDragging, setIsDragging] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
   const [showAddForm, setShowAddForm] = useState(false);
@@ -337,7 +363,7 @@ export default function TodoItem({
             {(childTasks.length > 0 || task.parentId) && ( // Show expand/collapse if it has children or is a child (to allow collapsing empty sub-lists)
               <button
                 onClick={() => {
-                  setIsExpanded(!isExpanded);
+                  setExpanded(!isExpanded);
                 }}
                 className="p-1 text-slate-500 dark:text-slate-400 hover:text-sky-600 dark:hover:text-sky-400 focus:outline-none"
                 title={isExpanded ? 'Collapse' : 'Expand'}

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -11,6 +11,8 @@ interface TodoListProps {
   onTaskChange?: () => void;
 }
 
+const EXPANDED_STATE_KEY = 't8d_expanded_tasks';
+
 export default function TodoList({ onTaskChange = () => {} }: TodoListProps) {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -18,11 +20,26 @@ export default function TodoList({ onTaskChange = () => {} }: TodoListProps) {
   const [quickTaskInput, setQuickTaskInput] = useState('');
   const [dragTargetItem, setDragTargetItem] = useState<string | null>(null);
 
+  // Expanded state persisted in localStorage
+  const [expandedState, setExpandedState] = useState<Record<string, boolean>>(() => {
+    try {
+      const stored = localStorage.getItem(EXPANDED_STATE_KEY);
+      return stored ? JSON.parse(stored) : {};
+    } catch {
+      return {};
+    }
+  });
+
   const listContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     loadTasks();
   }, []);
+
+  useEffect(() => {
+    // Persist expanded state
+    localStorage.setItem(EXPANDED_STATE_KEY, JSON.stringify(expandedState));
+  }, [expandedState]);
 
   const loadTasks = async () => {
     setIsLoading(true);
@@ -212,6 +229,8 @@ export default function TodoList({ onTaskChange = () => {} }: TodoListProps) {
                 }}
                 dragTarget={dragTargetItem}
                 tabIndex={0}
+                expandedState={expandedState}
+                setExpandedState={setExpandedState}
               />
             ))}
           </div>

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
 packages:
-  - 'frontend'
-  - 'backend'
+  - frontend
+  - backend
+
+ignoredBuiltDependencies:
+  - esbuild
+
+onlyBuiltDependencies:
+  - '@tailwindcss/oxide'


### PR DESCRIPTION
This PR resolves the issue where all subtasks were expanded by default when reopening the app. Now, the expanded/collapsed state of each task is saved and restored using `localStorage`. This ensures that only the tasks the user explicitly expanded remain open after a reload, providing a more intuitive and user-friendly experience.

## Changes

- Added persistent storage for the expanded/collapsed state of tasks in `TodoList.tsx` using `localStorage`.
- Passed `expandedState` and `setExpandedState` props to all `TodoItem` components, ensuring state is shared and updated across the task tree.
- Updated the logic in `TodoItem` to use the persisted expanded state, so the UI accurately reflects the user's previous interactions after reopening the app.

## Motivation

Previously, users experienced all subtasks being expanded by default upon reopening the application, leading to a cluttered and confusing interface. Persisting the expanded/collapsed state improves usability and matches user expectations for a modern task management app.



## Related Issue

Closes #46  – Inefficient application state on reopen (all subtasks expanded by default)

