### PR TITLE
fix: keep the application state as-is when reopened

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import DateTime from '@components/DateTime';
 import Settings from '@components/Settings';
 import TodoList from '@components/TodoList';
 import { SideBar } from '@src/components/Sidebar';
+import { loadTasks } from './utils/todo/todo';
 
 import '@src/App.css';
 
@@ -11,6 +12,11 @@ const App: React.FC = () => {
   const [selectedView, setSelectedView] = useState('tasks');
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [tasks, setTasks] = useState<Task[]>([]);
+
+  useEffect(() => {
+    setTasks(loadTasks());
+  }, []);
 
   const handleTaskChange = () => {
     setRefreshTrigger(prev => prev + 1);
@@ -56,7 +62,7 @@ const App: React.FC = () => {
                 <DateTime />
               </div>
             </header>
-            <TodoList key={refreshTrigger} onTaskChange={handleTaskChange} />
+            <TodoList key={refreshTrigger} onTaskChange={handleTaskChange} tasks={tasks} />
           </div>
         )}
         {selectedView === 'settings' && (

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -19,6 +19,7 @@ export default function TodoList({ onTaskChange = () => {} }: TodoListProps) {
   const [isDragOverRoot, setIsDragOverRoot] = useState(false);
   const [quickTaskInput, setQuickTaskInput] = useState('');
   const [dragTargetItem, setDragTargetItem] = useState<string | null>(null);
+  const [collapsedTasks, setCollapsedTasks] = useState<{ [key: string]: boolean }>({});
 
   // Expanded state persisted in localStorage
   const [expandedState, setExpandedState] = useState<Record<string, boolean>>(() => {
@@ -40,6 +41,21 @@ export default function TodoList({ onTaskChange = () => {} }: TodoListProps) {
     // Persist expanded state
     localStorage.setItem(EXPANDED_STATE_KEY, JSON.stringify(expandedState));
   }, [expandedState]);
+
+  useEffect(() => {
+    const initializeCollapsedState = (tasks: Task[]) => {
+      const state: { [key: string]: boolean } = {};
+      tasks.forEach(task => {
+        state[task.id] = true;
+        if (task.subtasks) {
+          Object.assign(state, initializeCollapsedState(task.subtasks));
+        }
+      });
+      return state;
+    };
+
+    setCollapsedTasks(initializeCollapsedState(tasks));
+  }, [tasks]);
 
   const loadTasks = async () => {
     setIsLoading(true);
@@ -231,6 +247,8 @@ export default function TodoList({ onTaskChange = () => {} }: TodoListProps) {
                 tabIndex={0}
                 expandedState={expandedState}
                 setExpandedState={setExpandedState}
+                isCollapsed={collapsedTasks[task.id]}
+                onToggleCollapse={() => toggleCollapse(task.id)}
               />
             ))}
           </div>

--- a/frontend/src/utils/todo/todo.ts
+++ b/frontend/src/utils/todo/todo.ts
@@ -104,3 +104,12 @@ export const getTask = async (id: string): Promise<Task | undefined> => {
 
   return task;
 };
+
+export const loadTasks = (): Task[] => {
+  const tasks = JSON.parse(localStorage.getItem('tasks') || '[]')
+  return tasks
+}
+
+export const saveTasks = (tasks: Task[]) => {
+  localStorage.setItem('tasks', JSON.stringify(tasks))
+}


### PR DESCRIPTION
This pull request introduces enhancements to the way tasks are loaded and managed in the application, particularly focusing on initializing and handling the collapsed state of tasks and improving task persistence with localStorage. The main changes include loading tasks from localStorage when the app starts, tracking the collapsed state of tasks (including nested subtasks), and adding utility functions for task persistence.

**Task loading and persistence improvements:**

* Added a `loadTasks` function in `frontend/src/utils/todo/todo.ts` to fetch tasks from localStorage, and a `saveTasks` function to persist tasks, centralizing task storage logic.
* Updated `frontend/src/App.tsx` to load tasks from localStorage on app initialization using the new `loadTasks` utility, and passed the loaded tasks down to the `TodoList` component. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL1-R19) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL59-R65)

**Task UI state management:**

* Introduced a `collapsedTasks` state in `frontend/src/components/TodoList.tsx` to track which tasks (and their subtasks) are collapsed, and initialized this state based on the loaded tasks. [[1]](diffhunk://#diff-bf640175e7ae6123964f0ce68566fe9b9a066e6644f9271f5827183479ac1388R22) [[2]](diffhunk://#diff-bf640175e7ae6123964f0ce68566fe9b9a066e6644f9271f5827183479ac1388R45-R59)
* Updated the rendering of tasks in `TodoList` to pass `isCollapsed` and `onToggleCollapse` props to each task, enabling proper UI control for collapsing and expanding tasks.