### PR TITLE
Make Task Name Clickable and Editable via Double-Click

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "t8d",
   "private": true,
   "homepage": "https://rahidmondal.github.io/T8D/",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "type": "module",
   "description": "T8D - A Simple Task Manager",
   "scripts": {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -118,7 +118,7 @@ export const SideBar: React.FC<SideBarProps> = ({ selectedView, onSelectView, se
 
       <div className="flex justify-center p-3 text-xs text-slate-500 dark:text-slate-400 border-t border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50">
         {' '}
-        <p>T8D v0.2.5</p>
+        <p>T8D v0.3.0</p>
       </div>
     </div>
   );

--- a/frontend/src/components/TodoItem.tsx
+++ b/frontend/src/components/TodoItem.tsx
@@ -281,7 +281,23 @@ export default function TodoItem({
             } cursor-pointer flex items-center gap-2`}
             onClick={toggleAddForm}
           >
-            {task.name}
+            <span
+              className="hover:underline focus:underline outline-none"
+              tabIndex={0}
+              title="Double-click to edit"
+              onDoubleClick={startEditing}
+              onKeyDown={e => {
+                if ((e.key === 'Enter' || e.key === ' ') && document.activeElement === e.currentTarget) {
+                  e.preventDefault();
+                  startEditing();
+                }
+              }}
+              role="button"
+              aria-label="Edit task name"
+              style={{ userSelect: 'text' }}
+            >
+              {task.name}
+            </span>
             <SubtaskCountBadge completed={completedSubtask} total={totalSubtasks} />
           </span>
 


### PR DESCRIPTION
This PR improves the `TodoItem` component by making the task name clickable and editable. Users can now double-click the task name to edit it, in addition to using the existing edit button. Keyboard accessibility is also supported.

## Changes

- Made the task name visually and programmatically clickable.
- Double-clicking the task name triggers the edit mode.
- Pressing Enter or Space while the task name is focused also triggers editing.
- Existing features and behaviors remain unchanged.

Closes #42 