### PR TITLE
Separate Completed Task Dropdown

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useState } from 'react';
 
 import DateTime from '@components/DateTime';
 import Settings from '@components/Settings';
+import { SideBar } from '@components/Sidebar';
 import TodoList from '@components/TodoList';
-import { SideBar } from '@src/components/Sidebar';
+
 import { loadTasks } from './utils/todo/todo';
 
 import '@src/App.css';


### PR DESCRIPTION
This pull request refactors the `TodoList` component to improve how completed tasks are managed and displayed, and simplifies several aspects of the codebase. The main changes include separating active and completed tasks, adding a collapsible "Completed" section with persistent state, and cleaning up unused or redundant logic. These updates enhance the user experience by making completed tasks easier to access and the code easier to maintain.

**Completed Tasks Section & State Persistence**
* Added a collapsible "Completed" section in the task list, allowing users to hide or show completed root tasks. The expanded/collapsed state is now persisted in `localStorage` using the new `COMPLETED_SECTION_EXPANDED_KEY`. [[1]](diffhunk://#diff-bf640175e7ae6123964f0ce68566fe9b9a066e6644f9271f5827183479ac1388R14-R30) [[2]](diffhunk://#diff-bf640175e7ae6123964f0ce68566fe9b9a066e6644f9271f5827183479ac1388L41-R59) [[3]](diffhunk://#diff-bf640175e7ae6123964f0ce68566fe9b9a066e6644f9271f5827183479ac1388L229-R255)

**Task Filtering and Display Logic**
* Refactored task filtering logic to separate active and completed root tasks, and updated the UI to display these groups distinctly. The code now uses `getActiveRootTasks` and `getCompletedRootTasks` functions for clarity. [[1]](diffhunk://#diff-bf640175e7ae6123964f0ce68566fe9b9a066e6644f9271f5827183479ac1388L146-L158) [[2]](diffhunk://#diff-bf640175e7ae6123964f0ce68566fe9b9a066e6644f9271f5827183479ac1388R157-R159) [[3]](diffhunk://#diff-bf640175e7ae6123964f0ce68566fe9b9a066e6644f9271f5827183479ac1388L229-R255)


**Imports and Path Consistency**
* Standardized import paths to use the `@src` alias for consistency across components and utility imports. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR5-R7) [[2]](diffhunk://#diff-bf640175e7ae6123964f0ce68566fe9b9a066e6644f9271f5827183479ac1388L4-R5)

**UI and UX Improvements**
* Updated empty state messaging and improved the appearance of the completed section toggle, making the interface more user-friendly and visually consistent. [[1]](diffhunk://#diff-bf640175e7ae6123964f0ce68566fe9b9a066e6644f9271f5827183479ac1388L229-R255) [[2]](diffhunk://#diff-bf640175e7ae6123964f0ce68566fe9b9a066e6644f9271f5827183479ac1388L250-R281)

Closes #47 